### PR TITLE
Add modern styling with fade animations

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,10 +1,13 @@
 #root {
-  max-width: 1280px;
-  /* margin: 0 auto; */
-  padding: 2rem;
+  max-width: 800px;
+  margin: 40px auto;
   text-align: center;
-  background-color: #ecf0f3;
-  box-shadow: 10px 10px 10px #d1d9e6, -10px -10px 10px #f9f9f9;
-  border-radius: 12px;
-  margin:20px auto;
+}
+
+.form-container {
+  background: rgba(255, 255, 255, 0.8);
+  padding: 2rem;
+  border-radius: 1rem;
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.1);
+  backdrop-filter: blur(4px);
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,7 @@ function App() {
   }
 
   return (
-    <div className='flex flex-col sm:flex-row'>
+    <div className="form-container fade-in flex flex-col sm:flex-row gap-6">
       <div className='flex-1'>
         <C.StringInput label='Name' value={data.name} onChange={(v)=>update('name',v)} error={errors.name}/>
         <C.IntegerInput label='Integer' value={data.integer} onChange={(v)=>update('integer',v)} error={errors.integer}/>
@@ -43,7 +43,7 @@ function App() {
         <C.SelectInput label="Select unit" value={data.select} onChange={(v) => update('select', v)} items={selectItems} error={errors.select} />
         <C.ComboboxInput label="EPSG code" value={data.combobox} onChange={(v) => update('combobox', v)} items={EpsgData()} error={errors.combobox} />
       </div>
-      <div className='flex-1 mt-3'>
+      <div className='flex-1 mt-3 sm:mt-0'>
         <pre className='text-left text-[#6f7e87] flex justify-center text-shadow-custom'>{JSON.stringify(data, null, 2)}</pre>
       </div>
     </div>

--- a/src/components/inputs/ComboboxInput.tsx
+++ b/src/components/inputs/ComboboxInput.tsx
@@ -21,7 +21,7 @@ const ComboboxInput = ({ label, value, onChange, items, error } : Props) => {
     onChange(v)
   }
   return (
-    <div className="mb-3">
+    <div className="mb-3 fade-in">
       <label className={componentsStyle.body}>
               <span className={labelStyle(error)}>{label}</span>
       <input

--- a/src/components/inputs/DateInput.tsx
+++ b/src/components/inputs/DateInput.tsx
@@ -10,7 +10,7 @@ interface Props{
 }
 const DateInput= ({ label, value, onChange, error, minValue, maxValue }: Props) => {
   return (
-    <div className="mb-3">
+    <div className="mb-3 fade-in">
       <label className={componentsStyle.body}>
         <span className={labelStyle(error)}>{label}</span>
         <input

--- a/src/components/inputs/DateTimeInput.tsx
+++ b/src/components/inputs/DateTimeInput.tsx
@@ -8,7 +8,7 @@ interface Props {
 }
 const DateTimeInput = ({ label, value, onChange, error }:Props) => {
   return (
-    <div className="mb-3">
+    <div className="mb-3 fade-in">
       <label className={componentsStyle.body}>
         <span className={labelStyle(error)}>{label}</span>
         <input

--- a/src/components/inputs/DurationInput.tsx
+++ b/src/components/inputs/DurationInput.tsx
@@ -16,7 +16,7 @@ const DurationInput = ({ label, value, onChange, error}:Props) => {
       }
   }
   return (
-    <div className="mb-3">
+    <div className="mb-3 fade-in">
       <label className={componentsStyle.body}>
         <span className={labelStyle(error)}>{label}</span>
         <input className={componentsStyle.input} type="number" value={value} onChange={handle} />

--- a/src/components/inputs/ExtentInput.tsx
+++ b/src/components/inputs/ExtentInput.tsx
@@ -14,7 +14,7 @@ const ExtentInput= ({ label, value, onChange, error }:Props) => {
     onChange(nv)
   }
   return (
-    <div className="mb-3">
+    <div className="mb-3 fade-in">
       <label className={`${componentsStyle.body} h-24`}>
         <span className={labelStyle(error)}>{label}</span>
         <div className={componentsStyle.extentBox}>

--- a/src/components/inputs/FloatInput.tsx
+++ b/src/components/inputs/FloatInput.tsx
@@ -16,7 +16,7 @@ const FloatInput = ({ label, value, onChange, error } : Props) => {
       }
   }
   return (
-    <div className="mb-3">
+    <div className="mb-3 fade-in">
       <label className={componentsStyle.body}>
         <span className={labelStyle(error)}>{label}</span>
         <input 

--- a/src/components/inputs/IntegerInput.tsx
+++ b/src/components/inputs/IntegerInput.tsx
@@ -16,7 +16,7 @@ const IntegerInput = ({ label, value, onChange, error } : Props) => {
       }
     }
   return (
-    <div className="mb-3">
+    <div className="mb-3 fade-in">
       <label className={componentsStyle.body}>
         <span className={labelStyle(error)}>{label}</span>
         <input 

--- a/src/components/inputs/PointInput.tsx
+++ b/src/components/inputs/PointInput.tsx
@@ -9,7 +9,7 @@ interface Props {
 const PointInput= ({ label, value, onChange, error }:Props) => {
   const [x, y] = value
   return (
-    <div className="mb-3">
+    <div className="mb-3 fade-in">
         <label className={componentsStyle.body}>
                 <span className={labelStyle(error)}>{label} (x, y)</span>
       <div className={componentsStyle.pointBox}>

--- a/src/components/inputs/SelectInput.tsx
+++ b/src/components/inputs/SelectInput.tsx
@@ -9,7 +9,7 @@ interface Props {
 }
 const SelectInput = ({ label, value, onChange, items, error }:Props) => {
   return (
-    <div className="mb-3">
+    <div className="mb-3 fade-in">
       <label className={componentsStyle.body}>
         <span className={labelStyle(error)}>{label}</span>
         <select className={componentsStyle.input} value={value} onChange={(e) => onChange(e.target.value)}>

--- a/src/components/inputs/StringInput.tsx
+++ b/src/components/inputs/StringInput.tsx
@@ -10,7 +10,7 @@ interface Props {
 const StringInput = ({label,value,onChange,error}:Props) => {
     
     return (
-        <div className="mb-3">
+        <div className="mb-3 fade-in">
             <label className={componentsStyle.body}>
                 <span className={labelStyle(error)}>{label}</span>
                 <input className={componentsStyle.input} type="text" placeholder="Name" value={value} onChange={(e) => onChange(e.target.value)}/>

--- a/src/index.css
+++ b/src/index.css
@@ -10,10 +10,23 @@
   .text-shadow-custom-labels {
     text-shadow: 1px 1px 1px #829198;
   }
+  .fade-in {
+    @apply opacity-0;
+    animation: fade-in 0.5s ease-in-out forwards;
+  }
+}
+
+@keyframes fade-in {
+  from { opacity: 0; transform: translateY(10px); }
+  to { opacity: 1; transform: translateY(0); }
 }
 
 :root {
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
+}
+
+body {
+  @apply bg-gradient-to-br from-gray-100 to-blue-100 flex items-center justify-center min-h-screen;
 }


### PR DESCRIPTION
## Summary
- tweak root and body styling
- add fade-in animation utilities
- wrap form in new container with animation
- add fade-in classes to all input components

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683fd77d4b20832191bca64925fdd6e7