### PR TITLE
Fix float validation

### DIFF
--- a/src/utils/validators.ts
+++ b/src/utils/validators.ts
@@ -31,7 +31,8 @@ export function validateField<K extends keyof ConfigData>(
     }
 
     case "float": {
-      if (typeof value !== "number") return "Ungültiger Float-Wert";
+      if (typeof value !== "number" || !Number.isFinite(value))
+        return "Ungültiger Float-Wert";
       if (config?.minValue !== undefined && value < config.minValue)
         return `Muss mindestens ${config.minValue} sein`;
       if (config?.maxValue !== undefined && value > config.maxValue)


### PR DESCRIPTION
## Summary
- tighten validator for float values

## Testing
- `npm run lint` *(fails: cannot find module '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_683fd77d32988321b42aded1c7c17896